### PR TITLE
Add OSM display names and link to profile page

### DIFF
--- a/app/assets/scripts/components/common/link.js
+++ b/app/assets/scripts/components/common/link.js
@@ -1,4 +1,32 @@
+import React from 'react';
 import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import { filterComponentProps } from '../../utils';
+import { osmUrl } from '../../config';
 
-export default filterComponentProps(Link, ['hideText', 'useIcon', 'variation']);
+/**
+ * A base Link component ready to be used with styled component without warnings
+ */
+const StyledLink = filterComponentProps(Link, ['hideText', 'useIcon', 'variation']);
+
+/**
+ * Link to OpenStreetMap Profile
+ */
+export const LinkToOsmProfile = ({ osmDisplayName, className }) => {
+  return (
+    <a
+      className={className}
+      href={`${osmUrl}/user/${osmDisplayName}`}
+      target='_blank'
+      rel='noopener noreferrer'
+    >
+      {osmDisplayName}
+    </a>
+  );
+};
+LinkToOsmProfile.propTypes = {
+  osmDisplayName: PropTypes.string.isRequired,
+  className: PropTypes.string
+};
+
+export default StyledLink;

--- a/app/assets/scripts/components/photos/index.js
+++ b/app/assets/scripts/components/photos/index.js
@@ -175,7 +175,7 @@ class Photos extends React.Component {
           <td>
             <Link to={`/photos/${photo.id}`}>{photo.id}</Link>
           </td>
-          <td>{photo.ownerId}</td>
+          <td>{photo.ownerDisplayName}</td>
           <td>{new Date(photo.createdAt).toLocaleDateString()}</td>
           <td>{featureToCoords(photo.location)}</td>
           <td>W W N</td>

--- a/app/assets/scripts/components/photos/view.js
+++ b/app/assets/scripts/components/photos/view.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
-import { environment } from '../../config';
+import { environment, osmUrl } from '../../config';
 import * as actions from '../../redux/actions/photos';
 import { showGlobalLoading, hideGlobalLoading } from '../common/global-loading';
 import { featureToCoords, formatDateTimeExtended } from '../../utils';
@@ -113,7 +113,7 @@ class Photos extends React.Component {
               {osmObjects.map((o, i) => (
                 <li key={o}>
                   <a
-                    href={`https://www.openstreetmap.org/${o}`}
+                    href={`${osmUrl}/${o}`}
                     target='_blank'
                     rel='noopener noreferrer'
                   >

--- a/app/assets/scripts/components/photos/view.js
+++ b/app/assets/scripts/components/photos/view.js
@@ -24,6 +24,7 @@ import Button from '../../styles/button/button';
 import Prose from '../../styles/type/prose';
 import { wrapApiResult, getFromState } from '../../redux/utils';
 import { ContentWrapper, Infobox, ActionButtonsWrapper } from '../common/view-wrappers';
+import { LinkToOsmProfile } from '../common/link';
 
 const PhotoBox = styled.div`
   img {
@@ -83,7 +84,7 @@ class Photos extends React.Component {
     const {
       id,
       description,
-      ownerId,
+      ownerDisplayName,
       location,
       bearing,
       osmObjects,
@@ -99,7 +100,9 @@ class Photos extends React.Component {
           <FormLabel>Description</FormLabel>
           <p>{description || 'No description available.'}</p>
           <FormLabel>Owner</FormLabel>
-          <p>{ownerId}</p>
+          <p>
+            <LinkToOsmProfile osmDisplayName={ownerDisplayName} />
+          </p>
           <FormLabel>Location</FormLabel>
           <p>{featureToCoords(location)}</p>
           <FormLabel>Bearing</FormLabel>

--- a/app/assets/scripts/components/traces/index.js
+++ b/app/assets/scripts/components/traces/index.js
@@ -202,7 +202,7 @@ class Traces extends React.Component {
           <td>
             <Link to={`/traces/${trace.id}`}>{trace.id}</Link>
           </td>
-          <td>{trace.ownerId}</td>
+          <td>{trace.ownerDisplayName}</td>
           <td>{new Date(trace.recordedAt).toLocaleDateString()}</td>
           <td>{trace.length}</td>
           <td>JOSM Icon</td>

--- a/app/assets/scripts/components/traces/view.js
+++ b/app/assets/scripts/components/traces/view.js
@@ -25,6 +25,7 @@ import { formatDateTimeExtended, startCoordinate } from '../../utils';
 import Form from '../../styles/form/form';
 import FormLabel from '../../styles/form/label';
 import { ContentWrapper, Infobox, ActionButtonsWrapper } from '../common/view-wrappers';
+import { LinkToOsmProfile } from '../common/link';
 
 // Mapbox access token
 mapboxgl.accessToken = mapboxAccessToken;
@@ -145,7 +146,9 @@ class Traces extends React.Component {
           <FormLabel>Length</FormLabel>
           <p>{trace.length}</p>
           <FormLabel>Owner</FormLabel>
-          <p>{trace.ownerId}</p>
+          <p>
+            <LinkToOsmProfile osmDisplayName={trace.ownerDisplayName} />
+          </p>
           <FormLabel>Start coordinate</FormLabel>
           <p>{startCoordinate(geometry)}</p>
           <FormLabel>Recorded at</FormLabel>

--- a/app/assets/scripts/config/defaults.js
+++ b/app/assets/scripts/config/defaults.js
@@ -6,5 +6,6 @@ export default {
   appDescription: 'A dashboard to browse and manage Observe platform data.',
   baseUrl: 'http://localhost:9000',
   apiUrl: 'http://localhost:3000',
+  osmUrl: 'https://master.apis.dev.openstreetmap.org',
   mapboxAccessToken: 'pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJjanJxemxwMDYxODU4NDRrNXIyYjNndGtrIn0.zpS8B_awWF-3xAQJeAO9xA'
 };


### PR DESCRIPTION
Traces/photos list pages are now showing display names instead of OSM ids. Also, individual pages now include link to user profile page at OSM, as the dashboard won't have user profile pages for the moment.

@LanesGood this is ready for review.