### PR TITLE
fix case on import of inpage component

### DIFF
--- a/app/assets/scripts/components/traces/index.js
+++ b/app/assets/scripts/components/traces/index.js
@@ -18,7 +18,7 @@ import {
   InpageTitle,
   InpageBody,
   InpageBodyInner
-} from '../common/Inpage';
+} from '../common/inpage';
 import Button from '../../styles/button/button';
 import Form from '../../styles/form/form';
 import FormInput from '../../styles/form/input';


### PR DESCRIPTION
Minor: Fixes import of `inpage` component on traces screen (use lowercase `inpage` instead of `Inpage` to match case of the filename.

Am not sure if the case sensitivity is not a problem on other OSes, but on Ubuntu, having the wrong case on the import was causing the import to fail.

cc @vgeorge 