### PR TITLE
Photo view page items

### DIFF
--- a/app/assets/scripts/components/common/inpage.js
+++ b/app/assets/scripts/components/common/inpage.js
@@ -49,6 +49,7 @@ export const InpageBackLink = styled(Link)`
   display:flex;
   position: relative;
   top: -0.5rem;
+  text-decoration: none;
   &:before{
     ${collecticon('chevron-left--small')};
   }

--- a/app/assets/scripts/components/common/page-header.js
+++ b/app/assets/scripts/components/common/page-header.js
@@ -28,6 +28,9 @@ const PageHeadInner = styled.div`
   align-items: center;
   justify-content: space-between;
   min-width: 100%;
+  a {
+    text-decoration: none;
+  }
 `;
 
 const PageTitle = styled.h1`

--- a/app/assets/scripts/components/common/view-wrappers.js
+++ b/app/assets/scripts/components/common/view-wrappers.js
@@ -31,9 +31,6 @@ export const Infobox = styled.div`
       list-style: none;
       margin: 0;
     }
-    a {
-      text-decoration: underline;
-    }
   }
 `;
 

--- a/app/assets/scripts/components/photos/index.js
+++ b/app/assets/scripts/components/photos/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
 import { Link } from 'react-router-dom';
-import { environment } from '../../config';
+import { environment, osmUrl } from '../../config';
 import * as actions from '../../redux/actions/photos';
 import { showGlobalLoading, hideGlobalLoading } from '../common/global-loading';
 import DataTable from '../../styles/table';
@@ -24,7 +24,8 @@ import {
   InputWrapper,
   InputWithIcon,
   InputIcon,
-  FilterLabel } from '../../styles/form/filters';
+  FilterLabel
+} from '../../styles/form/filters';
 
 import Pagination from '../../styles/button/pagination';
 import Prose from '../../styles/type/prose';
@@ -75,7 +76,11 @@ class Photos extends React.Component {
         <FilterToolbar>
           <InputWrapper>
             <FilterLabel htmlFor='userSearch'>Search by user</FilterLabel>
-            <InputWithIcon type='text' id='userSearch' placeholder='User Name' />
+            <InputWithIcon
+              type='text'
+              id='userSearch'
+              placeholder='User Name'
+            />
             <InputIcon htmlFor='userSearch' useIcon='magnifier-left' />
           </InputWrapper>
           <InputWrapper>
@@ -138,7 +143,7 @@ class Photos extends React.Component {
               <span>Coordinates</span>
             </th>
             <th scope='col'>
-              <span>OSM Objects</span>
+              <span>OSM Element</span>
             </th>
             <th scope='col'>
               <span>Actions</span>
@@ -161,7 +166,19 @@ class Photos extends React.Component {
           <td>{photo.ownerDisplayName}</td>
           <td>{new Date(photo.createdAt).toLocaleDateString()}</td>
           <td>{featureToCoords(photo.location)}</td>
-          <td>W W N</td>
+          <td>
+            {photo.osmElement ? (
+              <a
+                target='_blank'
+                rel='noopener noreferrer'
+                href={`${osmUrl}/${photo.osmElement}`}
+              >
+                {photo.osmElement}
+              </a>
+            ) : (
+              '-'
+            )}
+          </td>
           <td>...</td>
         </tr>
       );
@@ -207,7 +224,4 @@ function dispatcher (dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  dispatcher
-)(Photos);
+export default connect(mapStateToProps, dispatcher)(Photos);

--- a/app/assets/scripts/components/photos/view.js
+++ b/app/assets/scripts/components/photos/view.js
@@ -177,7 +177,7 @@ class Photos extends React.Component {
       ownerDisplayName,
       location,
       bearing,
-      osmObjects,
+      osmElement,
       createdAt,
       uploadedAt
     } = photo;
@@ -221,23 +221,17 @@ class Photos extends React.Component {
           <p>{featureToCoords(location)}</p>
           <FormLabel>Bearing</FormLabel>
           <p>{bearing}</p>
-          <FormLabel>OSM Objects</FormLabel>
-          {osmObjects && osmObjects.length > 0 ? (
-            <ul>
-              {osmObjects.map((o, i) => (
-                <li key={o}>
-                  <a
-                    href={`${osmUrl}/${o}`}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                  >
-                    {o}
-                  </a>
-                </li>
-              ))}
-            </ul>
+          <FormLabel>OSM Element</FormLabel>
+          {osmElement ? (
+            <a
+              target='_blank'
+              rel='noopener noreferrer'
+              href={`${osmUrl}/${osmElement}`}
+            >
+              {osmElement}
+            </a>
           ) : (
-            <p>No assigned objects</p>
+            <p>Unassigned.</p>
           )}
           <FormLabel>Created at</FormLabel>
           <p>{formatDateTimeExtended(createdAt)}</p>

--- a/app/assets/scripts/components/photos/view.js
+++ b/app/assets/scripts/components/photos/view.js
@@ -6,6 +6,7 @@ import { environment, osmUrl } from '../../config';
 import { featureToCoords, formatDateTimeExtended } from '../../utils';
 import { wrapApiResult, getFromState, deleteItem } from '../../redux/utils';
 import * as actions from '../../redux/actions/photos';
+import { saveAs } from 'file-saver';
 
 import App from '../common/app';
 import { showGlobalLoading, hideGlobalLoading } from '../common/global-loading';
@@ -164,7 +165,7 @@ class Photos extends React.Component {
       <PhotoBox>
         <img
           alt={`Photo {photo.id}`}
-          src='https://via.placeholder.com/800x600'
+          src={photo.urls.default}
         />
       </PhotoBox>
     );
@@ -265,7 +266,7 @@ class Photos extends React.Component {
   }
 
   renderActionButtons (photo) {
-    const { ownerId, description } = photo;
+    const { ownerId, description, urls } = photo;
     const { osmId: userId, isAdmin } = this.props.authenticatedUser.getData();
 
     return (
@@ -295,6 +296,10 @@ class Photos extends React.Component {
           useIcon='download'
           variation='primary-raised-dark'
           size='xlarge'
+          onClick={e => {
+            e.preventDefault();
+            saveAs(urls.full, urls.full.split('/').pop());
+          }}
         >
           Download
         </Button>

--- a/app/assets/scripts/styles/global.js
+++ b/app/assets/scripts/styles/global.js
@@ -43,7 +43,6 @@ const baseStyles = css`
   a {
     cursor: pointer;
     color: ${themeVal('color.link')};
-    text-decoration: none;
     transition: opacity 0.24s ease 0s;
   }
   a:visited {

--- a/app/assets/scripts/styles/table.js
+++ b/app/assets/scripts/styles/table.js
@@ -54,15 +54,16 @@ const DataTable = styled.table`
 
   tbody {
     tr:hover {
-      background: ${_rgba(themeVal('color.smoke'), 0.25)};
-    }
-
-    tr: active {
       background: ${_rgba(themeVal('color.primary'), 0.25)};
     }
 
+    tr:active {
+      background: ${_rgba(themeVal('color.smoke'), 0.25)};
+    }
+
     a {
-      color: ${themeVal('color.base')};
+      color: ${_rgba(themeVal('color.primary'), 0.75)};
+    
     }
   }
 `;

--- a/app/assets/scripts/utils.js
+++ b/app/assets/scripts/utils.js
@@ -33,10 +33,7 @@ export function startCoordinate (feature) {
  * @param {string} date Date as ISO string
  */
 export function formatDateTimeExtended (date) {
-  return new Date(date).toLocaleDateString('en-GB', {
-    dateStyle: 'long',
-    timeStyle: 'short'
-  });
+  return new Date(date).toString();
 }
 
 /**


### PR DESCRIPTION
This PR replaces #40. It was rebased from `develop` and remaining items for view photo page were included.

Changes to review:

- Add link to OSM Element in photo index and view
- Display photo
- Enable "Download Photo" button
- Change date/time format

This is ready for review with code from https://github.com/developmentseed/observe-api/pull/36.