### PR TITLE
Rename "bearing" to "heading" in photo view

### DIFF
--- a/app/assets/scripts/components/photos/view.js
+++ b/app/assets/scripts/components/photos/view.js
@@ -177,7 +177,7 @@ class Photos extends React.Component {
       description,
       ownerDisplayName,
       location,
-      bearing,
+      heading,
       osmElement,
       createdAt,
       uploadedAt
@@ -220,8 +220,8 @@ class Photos extends React.Component {
           </p>
           <FormLabel>Location</FormLabel>
           <p>{featureToCoords(location)}</p>
-          <FormLabel>Bearing</FormLabel>
-          <p>{bearing}</p>
+          <FormLabel>Heading</FormLabel>
+          <p>{heading}°</p>
           <FormLabel>OSM Element</FormLabel>
           {osmElement ? (
             <a


### PR DESCRIPTION
Very small change. Also added `°` next to the value.