### PR TITLE
Update admin status

### DIFF
--- a/app/assets/scripts/components/common/profile-listener.js
+++ b/app/assets/scripts/components/common/profile-listener.js
@@ -12,6 +12,8 @@ class ProfileListener extends React.Component {
     setInterval(this.refreshUserProfile, refreshProfileInterval);
   }
 
+  componentDidMount () {
+    this.refreshUserProfile();
   }
 
   refreshUserProfile () {

--- a/app/assets/scripts/components/common/profile-listener.js
+++ b/app/assets/scripts/components/common/profile-listener.js
@@ -16,6 +16,10 @@ class ProfileListener extends React.Component {
     this.refreshUserProfile();
   }
 
+  componentWillUnmount () {
+    clearInterval(this.refreshUserProfile);
+  }
+
   refreshUserProfile () {
     if (this.props.isAuthenticated) {
       this.props.refreshProfile();

--- a/app/assets/scripts/components/common/profile-listener.js
+++ b/app/assets/scripts/components/common/profile-listener.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { wrapApiResult } from '../../redux/utils';
+import * as authActions from '../../redux/actions/auth';
+import { PropTypes as T } from 'prop-types';
+
+class ProfileListener extends React.Component {
+  constructor (props) {
+    super(props);
+    this.refreshUserProfile = this.refreshUserProfile.bind(this);
+    setInterval(this.refreshUserProfile, 2000);
+  }
+
+  refreshUserProfile () {
+    if (this.props.isAuthenticated) {
+      this.props.refreshProfile();
+    }
+  }
+
+  render () {
+    return null;
+  }
+}
+
+ProfileListener.propTypes = {
+  isAuthenticated: T.bool,
+  refreshProfile: T.func
+};
+
+function mapStateToProps (state) {
+  const { isReady, hasError } = wrapApiResult(state.authenticatedUser);
+  const isAuthenticated = isReady() && !hasError();
+
+  return {
+    isAuthenticated
+  };
+}
+
+function dispatcher (dispatch) {
+  return {
+    refreshProfile: (...args) => dispatch(authActions.refreshProfile(...args))
+  };
+}
+
+export default connect(mapStateToProps, dispatcher)(ProfileListener);

--- a/app/assets/scripts/components/common/profile-listener.js
+++ b/app/assets/scripts/components/common/profile-listener.js
@@ -3,12 +3,15 @@ import { connect } from 'react-redux';
 import { wrapApiResult } from '../../redux/utils';
 import * as authActions from '../../redux/actions/auth';
 import { PropTypes as T } from 'prop-types';
+import { refreshProfileInterval } from '../../config';
 
 class ProfileListener extends React.Component {
   constructor (props) {
     super(props);
     this.refreshUserProfile = this.refreshUserProfile.bind(this);
-    setInterval(this.refreshUserProfile, 2000);
+    setInterval(this.refreshUserProfile, refreshProfileInterval);
+  }
+
   }
 
   refreshUserProfile () {

--- a/app/assets/scripts/config/defaults.js
+++ b/app/assets/scripts/config/defaults.js
@@ -9,5 +9,6 @@ module.exports = {
   apiUrl: 'http://localhost:3000',
   osmUrl: 'https://master.apis.dev.openstreetmap.org',
   mapboxAccessToken: 'pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJjanJxemxwMDYxODU4NDRrNXIyYjNndGtrIn0.zpS8B_awWF-3xAQJeAO9xA',
-  pageLimit: 15
+  pageLimit: 15,
+  refreshProfileInterval: 5 * 60 * 1000 // 5 min
 };

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -26,6 +26,7 @@ import UhOh from './components/uhoh';
 import ErrorBoundary from './fatal-error-boundary';
 import ConfirmationPrompt from './components/common/confirmation-prompt';
 import { ToastContainerCustom } from './components/common/toasts';
+import ProfileListener from './components/common/profile-listener';
 
 // Root component. Used by the router.
 const Root = () => (
@@ -48,6 +49,7 @@ const Root = () => (
           </Switch>
           <ConfirmationPrompt />
           <ToastContainerCustom />
+          <ProfileListener />
         </ErrorBoundary>
       </ThemeProvider>
     </Router>

--- a/app/assets/scripts/redux/actions/auth.js
+++ b/app/assets/scripts/redux/actions/auth.js
@@ -41,11 +41,50 @@ export function authenticate (accessToken) {
   });
 }
 
+/**
+ * Performs an API request to fetch updated user profile data. As this
+ * function is intended to be used in a background task to keep admin
+ * status updated, it doesn't remove user data before performing the
+ * request or when an error occur to avoid interface "flashing". The
+ * implementation is basically the same of authenticate(), but the
+ * accessToken comes from the state and request/error actions do not
+ * change state.
+ */
 export function refreshProfile () {
   return async (dispatch, getState) => {
     const state = getState();
     const accessToken = get(state, 'authenticatedUser.data.accessToken');
-    dispatch(authenticate(accessToken));
+
+    fetchDispatchFactory({
+      statePath: ['authenticatedUser'],
+      url: `${apiUrl}/profile`,
+      options: {
+        headers: {
+          Authorization: accessToken
+        }
+      },
+      receiveFn: (data, error = null) => {
+        if (error) {
+          // On error, don't change state
+          return {
+            type: 'SILENT_ERROR_AUTHENTICATED_USER'
+          };
+        } else {
+          // On success, update the profile
+          return receiveAuthenticatedProfile(data);
+        }
+      },
+      requestFn: () => {
+        // Do not change state when starting a request
+        return {
+          type: 'SILENT_REQUEST_AUTHENTICATED_USER'
+        };
+      },
+      mutator: data => ({
+        ...data,
+        accessToken // include accessToken after successful request
+      })
+    })(dispatch, getState);
   };
 }
 

--- a/app/assets/scripts/redux/actions/auth.js
+++ b/app/assets/scripts/redux/actions/auth.js
@@ -1,5 +1,6 @@
 import { fetchDispatchFactory } from '../utils';
 import { apiUrl } from '../../config';
+import get from 'lodash.get';
 
 export const REQUEST_AUTHENTICATED_USER = 'REQUEST_AUTHENTICATED_USER';
 export const RECEIVE_AUTHENTICATED_USER = 'RECEIVE_AUTHENTICATED_USER';
@@ -38,6 +39,14 @@ export function authenticate (accessToken) {
       accessToken // include accessToken after successful request
     })
   });
+}
+
+export function refreshProfile () {
+  return async (dispatch, getState) => {
+    const state = getState();
+    const accessToken = get(state, 'authenticatedUser.data.accessToken');
+    dispatch(authenticate(accessToken));
+  };
 }
 
 export function logout () {


### PR DESCRIPTION
In order to update admin status of logged users (#34), this implements a listener component at root level that will fetch the user profile periodically.

The listerner is already implemented, but due to the use of `fetchDispatchFactory` the user profile is deleted before being updated, causing a "flashing" effect on the interface. I'll work on another way of fetching this data to avoid this. It is necessary also to make the refresh interval a configuration option.